### PR TITLE
Improve dev configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# gradle
+
+.gradle/
+build/
+out/
+classes/
+
+# eclipse
+
+*.launch
+
+# idea
+
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# vscode
+
+.settings/
+.vscode/
+bin/
+.classpath
+.project
+
+# macos
+
+*.DS_Store
+
+# fabric
+
+run/

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,11 @@ dependencies {
 }
 
 processResources {
+    inputs.properties([
+        "version": project.version,
+        "mc_version": project.minecraft_version
+    ])
+
     filesMatching("fabric.mod.json") {
         expand "version": project.version, "mc_version": project.minecraft_version
     }


### PR DESCRIPTION
set up [task inputs](https://docs.gradle.org/current/userguide/incremental_build.html#incremental_build) for the `processResources` task to prevent gradle using old `gradle.properties` values when building for the `version` & `minecraft_version` properties whenever they are modified

also set up `.gitignore` to prevent local files being automatically added to git when developing
gitignore template taken from [meteor addon template](https://github.com/MeteorDevelopment/meteor-addon-template/blob/master/.gitignore)