### PR TITLE
(1.21.5) Fix modules/commands that use CustomName

### DIFF
--- a/src/main/java/pwn/noobs/trouserstreak/modules/AirstrikePlus.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/AirstrikePlus.java
@@ -17,6 +17,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtDouble;
+import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -507,6 +508,10 @@ public class AirstrikePlus extends Module {
         blockState.putString("Name", "minecraft:" + blockName);
         entityTag.put("BlockState", blockState);
 
+        NbtCompound CustomNameNBT = new NbtCompound();
+        CustomNameNBT.putString("text", customName);
+        CustomNameNBT.putString("color", namecolour);
+        
         if (invincible.get()) entityTag.putBoolean("Invulnerable", invincible.get());
         if (silence.get()) entityTag.putBoolean("Silent", silence.get());
         if (glow.get()) entityTag.putBoolean("Glowing", glow.get());
@@ -519,7 +524,7 @@ public class AirstrikePlus extends Module {
         entityTag.putInt("Fuse", fuse.get());
         entityTag.putInt("Size", size.get());
         if (customname.get()) entityTag.putBoolean("CustomNameVisible", customname.get());
-        entityTag.putString("CustomName", "{\"text\":\"" + customName + "\",\"color\":\"" + namecolour + "\"}");
+        entityTag.put("CustomName", CustomNameNBT);
         return NbtComponent.of(entityTag);
     }
 
@@ -562,7 +567,7 @@ public class AirstrikePlus extends Module {
         String command = "/execute as @a at @s run summon " + entityName + " ";
         command += String.format("~%d ~%d ~%d", r.nextInt(radius.get() * 2) - radius.get(), height.get(), r.nextInt(radius.get() * 2) - radius.get());
         command += " {";
-        command += "\"CustomName\":\"{\\\"text\\\":\\\"" + customName + "\\\",\\\"color\\\":\\\"" + nameColor + "\\\"}\",";
+        command += "\"CustomName\":{\"text\":\"" + customName + "\",\"color\":\"" + nameColor + "\"},";
         command += "\"Health\":" + healthPoints + ",";
         if (Eabsorption.get() > 0) command += "\"AbsorptionAmount\":" + absorptionPoints + ",";
         if (EageSpecify.get()) command += "\"Age\":" + ageValue + ",";

--- a/src/main/java/pwn/noobs/trouserstreak/modules/AutoTexts.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/AutoTexts.java
@@ -202,9 +202,13 @@ public class AutoTexts extends Module {
 
     private NbtComponent createEntityData(Vec3d pos) {
         NbtCompound entityTag = new NbtCompound();
-        NbtList position = new NbtList();
-        String selectedText = texts.get().get(random.nextInt(texts.get().size()));
 
+        String selectedText = texts.get().get(random.nextInt(texts.get().size()));
+        NbtCompound customName = new NbtCompound();
+        customName.putString("text", selectedText);
+        customName.putString("color", namecolour);
+
+        NbtList position = new NbtList();
         position.add(NbtDouble.of(pos.x));
         position.add(NbtDouble.of(pos.y));
         position.add(NbtDouble.of(pos.z));
@@ -215,7 +219,7 @@ public class AutoTexts extends Module {
         entityTag.putBoolean("Marker", true);
         entityTag.putBoolean("NoGravity", true);
         entityTag.putBoolean("CustomNameVisible", true);
-        entityTag.putString("CustomName", "{\"text\":\"" + selectedText + "\",\"color\":\"" + namecolour + "\"}");
+        entityTag.put("CustomName", customName);
 
         return NbtComponent.of(entityTag);
     }

--- a/src/main/java/pwn/noobs/trouserstreak/modules/BoomPlus.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/BoomPlus.java
@@ -183,8 +183,6 @@ public class BoomPlus extends Module {
         super(Trouser.Main, "boom+", "shoots something where you click");
     }
     private int aticks=0;
-    private String namecolour = nomcolor.get().toString();
-    private String customName = nom.get();
 
     @EventHandler
     public void onTick(TickEvent.Post event) {
@@ -197,14 +195,12 @@ public class BoomPlus extends Module {
             if (aticks<=atickdelay.get()){
                 aticks++;
             } else if (aticks>atickdelay.get()) {
-                customName = nom.get();
-                namecolour = nomcolor.get().toString();
                 ItemStack rst = mc.player.getMainHandStack();
                 BlockHitResult bhr = new BlockHitResult(mc.player.getEyePos(), Direction.DOWN, BlockPos.ofFloored(mc.player.getEyePos()), false);
                 ItemStack item = new ItemStack(Items.BEE_SPAWN_EGG);
                 var changes = ComponentChanges.builder()
-                        .add(DataComponentTypes.CUSTOM_NAME, Text.literal(customName).formatted(Formatting.valueOf(namecolour.toUpperCase())))
-                        .add(DataComponentTypes.ITEM_NAME, Text.literal(customName).formatted(Formatting.valueOf(namecolour.toUpperCase())))
+                        .add(DataComponentTypes.CUSTOM_NAME, Text.literal(nom.get()).formatted(Formatting.valueOf(nomcolor.get().name().toUpperCase())))
+                        .add(DataComponentTypes.ITEM_NAME, Text.literal(nom.get()).formatted(Formatting.valueOf(nomcolor.get().name().toUpperCase())))
                         .add(DataComponentTypes.ENTITY_DATA, createEntityData())
                         .build();
                 item.applyChanges(changes);
@@ -219,14 +215,12 @@ public class BoomPlus extends Module {
     @EventHandler
     private void onMouseButton(MouseButtonEvent event) {
         if (mc.options.attackKey.isPressed() && mc.currentScreen == null && mc.player.getAbilities().creativeMode) {
-            customName = nom.get();
-            namecolour = nomcolor.get().toString();
             ItemStack rst = mc.player.getMainHandStack();
             BlockHitResult bhr = new BlockHitResult(mc.player.getEyePos(), Direction.DOWN, BlockPos.ofFloored(mc.player.getEyePos()), false);
             ItemStack item = new ItemStack(Items.BEE_SPAWN_EGG);
             var changes = ComponentChanges.builder()
-                    .add(DataComponentTypes.CUSTOM_NAME, Text.literal(customName).formatted(Formatting.valueOf(namecolour.toUpperCase())))
-                    .add(DataComponentTypes.ITEM_NAME, Text.literal(customName).formatted(Formatting.valueOf(namecolour.toUpperCase())))
+                    .add(DataComponentTypes.CUSTOM_NAME, Text.literal(nom.get()).formatted(Formatting.valueOf(nomcolor.get().name().toUpperCase())))
+                    .add(DataComponentTypes.ITEM_NAME, Text.literal(nom.get()).formatted(Formatting.valueOf(nomcolor.get().name().toUpperCase())))
                     .add(DataComponentTypes.ENTITY_DATA, createEntityData())
                     .build();
             item.applyChanges(changes);
@@ -247,6 +241,10 @@ public class BoomPlus extends Module {
         BlockPos pos = BlockPos.ofFloored(owo);
         Vec3d sex = mc.player.getRotationVector().multiply(speed.get());
         String entityName = entity.get().trim().replace(" ", "_");
+
+        NbtCompound customName = new NbtCompound();
+        customName.putString("text", nom.get());
+        customName.putString("color", nomcolor.get().name());
 
         NbtCompound entityTag = new NbtCompound();
         if (target.get()) {
@@ -281,7 +279,7 @@ public class BoomPlus extends Module {
         entityTag.putInt("Fuse", fuse.get());
         entityTag.putInt("Size", size.get());
         if(customname.get())entityTag.putBoolean("CustomNameVisible", customname.get());
-        entityTag.putString("CustomName", "{\"text\":\"" + nom.get() + "\",\"color\":\"" + nomcolor.get() + "\"}");
+        entityTag.put("CustomName", customName);
         return NbtComponent.of(entityTag);
     }
 }

--- a/src/main/java/pwn/noobs/trouserstreak/modules/NbtEditor.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/NbtEditor.java
@@ -381,6 +381,11 @@ public class NbtEditor extends Module {
 
     private NbtComponent createEntityData() {
         String entityName = entity.get().trim().replace(" ", "_");
+        
+        NbtCompound customName = new NbtCompound();
+        customName.putString("text", nom.get());
+        customName.putString("color", nomcolor.get().name());
+        
         NbtCompound entityTag = new NbtCompound();
         entityTag.putString("id", "minecraft:" + entityName);
         entityTag.putInt("Health", health.get());
@@ -400,7 +405,7 @@ public class NbtEditor extends Module {
         entityTag.putInt("Fuse", fuse.get());
         entityTag.putInt("Size", size.get());
         if(customname.get())entityTag.putBoolean("CustomNameVisible", customname.get());
-        entityTag.putString("CustomName", "{\"text\":\"" + nom.get() + "\",\"color\":\"" + nomcolor.get() + "\"}");
+        entityTag.put("CustomName", customName);
         entityTag.putInt("Radius", cloudradius.get());
         entityTag.putInt("Duration", cloudduration.get());
         entityTag.putString("Particle", particle.get());


### PR DESCRIPTION
Tested on a 1.21.5 fabric server with ViaBackwards
! This PR should only be merged when the mod is updated for 1.21.5 !

Fixed these modules:
- Airstrike+
- Boom+
- AutoTexts
- NbtEditor (i wasnt able to get this one to spawn anything? i think this ones just broken)

Fixed these commands:
- text
  - i rewrote the text parser to take care of a couple issues