### PR TITLE
Stop MaceKill from killing you

### DIFF
--- a/src/main/java/pwn/noobs/trouserstreak/modules/MaceKill.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/MaceKill.java
@@ -47,73 +47,64 @@ public class MaceKill extends Module {
 
     @EventHandler
     private void onSendPacket(PacketEvent.Send event) {
-        if (mc.player != null && mc.player.getMainHandStack().getItem() == Items.MACE && event.packet instanceof IPlayerInteractEntityC2SPacket packet && packet.meteor$getType() == PlayerInteractEntityC2SPacket.InteractType.ATTACK) {
-            try {
-                if (packet.meteor$getEntity() instanceof LivingEntity) {
-                    LivingEntity targetEntity = (LivingEntity) packet.meteor$getEntity();
+        if (mc.player == null) return;
+        if (mc.player.getMainHandStack().getItem() != Items.MACE) return;
+        if (!(event.packet instanceof IPlayerInteractEntityC2SPacket packet)) return;
+        if (packet.meteor$getType() != PlayerInteractEntityC2SPacket.InteractType.ATTACK) return;
 
-                    if (packetDisable.get() && (targetEntity.isBlocking() || targetEntity.isInvulnerable() || targetEntity.isInCreativeMode())) return;
-                    previouspos = mc.player.getPos();
-                    int blocks = getMaxHeightAbovePlayer();
+        LivingEntity targetEntity = (LivingEntity) packet.meteor$getEntity();
+        if (packetDisable.get() && (targetEntity.isBlocking() || targetEntity.isInvulnerable() || targetEntity.isInCreativeMode())) return;
 
-                    int packetsRequired = (int) Math.ceil(Math.abs(blocks / 10));
+        previouspos = mc.player.getPos();
+        int blocks = getMaxHeightAbovePlayer();
 
-                    if (packetsRequired > 20) {
-                        packetsRequired = 1;
-                    }
-                    BlockPos isopenair1 = (mc.player.getBlockPos().add(0, blocks, 0));
-                    BlockPos isopenair2 = (mc.player.getBlockPos().add(0, blocks + 1, 0));
-                    if (isSafeBlock(isopenair1) && isSafeBlock(isopenair2)) {
-                        if (blocks <= 22) {
-                            if (mc.player.hasVehicle()) {
-                                for (int i = 0; i < 4; i++) {
-                                    mc.player.networkHandler.sendPacket(VehicleMoveC2SPacket.fromVehicle(mc.player.getVehicle()));
-                                }
-                                double maxHeight = Math.min(mc.player.getVehicle().getY() + 22, mc.player.getVehicle().getY() + blocks);
-                                mc.player.getVehicle().setPosition(mc.player.getVehicle().getX(), maxHeight + blocks, mc.player.getVehicle().getZ());
-                                mc.player.networkHandler.sendPacket(VehicleMoveC2SPacket.fromVehicle(mc.player.getVehicle()));
-                                mc.player.getVehicle().setPosition(previouspos);
-                                mc.player.networkHandler.sendPacket(VehicleMoveC2SPacket.fromVehicle(mc.player.getVehicle()));
-                            } else {
-                                for (int i = 0; i < 4; i++) {
-                                    mc.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.OnGroundOnly(false, mc.player.horizontalCollision));
-                                }
-                                double maxHeight = Math.min(mc.player.getY() + 22, mc.player.getY() + blocks);
-                                PlayerMoveC2SPacket movepacket = new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), maxHeight, mc.player.getZ(), false, mc.player.horizontalCollision);
-                                PlayerMoveC2SPacket homepacket = new PlayerMoveC2SPacket.PositionAndOnGround(previouspos.getX(), previouspos.getY(), previouspos.getZ(), false, mc.player.horizontalCollision);
-                                ((IPlayerMoveC2SPacket) homepacket).meteor$setTag(1337);
-                                ((IPlayerMoveC2SPacket) movepacket).meteor$setTag(1337);
-                                mc.player.networkHandler.sendPacket(movepacket);
-                                mc.player.networkHandler.sendPacket(homepacket);
-                            }
-                        } else {
-                            if (mc.player.hasVehicle()) {
-                                for (int packetNumber = 0; packetNumber < (packetsRequired - 1); packetNumber++) {
-                                    mc.player.networkHandler.sendPacket(VehicleMoveC2SPacket.fromVehicle(mc.player.getVehicle()));
-                                }
-                                double maxHeight = mc.player.getVehicle().getY() + blocks;
-                                mc.player.getVehicle().setPosition(mc.player.getVehicle().getX(), maxHeight + blocks, mc.player.getVehicle().getZ());
-                                mc.player.networkHandler.sendPacket(VehicleMoveC2SPacket.fromVehicle(mc.player.getVehicle()));
-                                mc.player.getVehicle().setPosition(previouspos);
-                                mc.player.networkHandler.sendPacket(VehicleMoveC2SPacket.fromVehicle(mc.player.getVehicle()));
-                            } else {
-                                for (int packetNumber = 0; packetNumber < (packetsRequired - 1); packetNumber++) {
-                                    mc.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.OnGroundOnly(false, mc.player.horizontalCollision));
-                                }
-                                double maxHeight = mc.player.getY() + blocks;
-                                PlayerMoveC2SPacket movepacket = new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), maxHeight, mc.player.getZ(), false, mc.player.horizontalCollision);
-                                PlayerMoveC2SPacket homepacket = new PlayerMoveC2SPacket.PositionAndOnGround(previouspos.getX(), previouspos.getY(), previouspos.getZ(), false, mc.player.horizontalCollision);
-                                ((IPlayerMoveC2SPacket) homepacket).meteor$setTag(1337);
-                                ((IPlayerMoveC2SPacket) movepacket).meteor$setTag(1337);
-                                mc.player.networkHandler.sendPacket(movepacket);
-                                mc.player.networkHandler.sendPacket(homepacket);
-                            }
-                        }
-                    }
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
+        int packetsRequired = (int) Math.ceil(Math.abs(blocks / 10.0));
+        if (packetsRequired > 20) packetsRequired = 1;
+
+        BlockPos isopenair1 = mc.player.getBlockPos().add(0, blocks, 0);
+        BlockPos isopenair2 = mc.player.getBlockPos().add(0, blocks + 1, 0);
+        if (!isSafeBlock(isopenair1) || !isSafeBlock(isopenair2)) return;
+
+        // Vehicle branch
+        if (mc.player.hasVehicle()) {
+            // send a few vanilla packets first
+            for (int i = 0; i < (blocks <= 22 ? 4 : packetsRequired - 1); i++) {
+                mc.player.networkHandler.sendPacket(VehicleMoveC2SPacket.fromVehicle(mc.player.getVehicle()));
             }
+            double heightY = mc.player.getVehicle().getY() + blocks;
+            mc.player.getVehicle().setPosition(mc.player.getVehicle().getX(), heightY + (blocks <= 22 ? Math.min(22, blocks) : blocks), mc.player.getVehicle().getZ());
+            mc.player.networkHandler.sendPacket(VehicleMoveC2SPacket.fromVehicle(mc.player.getVehicle()));
+
+            // land you just 0.5 blocks above original
+            mc.player.getVehicle().setPosition(previouspos.getX(), previouspos.getY() + 0.5, previouspos.getZ());
+            mc.player.networkHandler.sendPacket(VehicleMoveC2SPacket.fromVehicle(mc.player.getVehicle()));
+
+            // tiny upward thrust & no fallDistance
+            mc.player.getVehicle().setVelocity(0, 0.1, 0);
+            mc.player.fallDistance = 0;
+
+        } else {
+            // Player-only branch :contentReference[oaicite:0]{index=0}&#8203;:contentReference[oaicite:1]{index=1}
+            for (int i = 0; i < (blocks <= 22 ? 4 : packetsRequired - 1); i++) {
+                mc.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.OnGroundOnly(false, mc.player.horizontalCollision));
+            }
+            double heightY = mc.player.getY() + blocks;
+            PlayerMoveC2SPacket movepacket = new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(), heightY, mc.player.getZ(), false, mc.player.horizontalCollision);
+            PlayerMoveC2SPacket homepacket = new PlayerMoveC2SPacket.PositionAndOnGround(
+                    previouspos.getX(),
+                    previouspos.getY() + 0.5,                  // land 0.5 blocks above original :contentReference[oaicite:2]{index=2}&#8203;:contentReference[oaicite:3]{index=3}
+                    previouspos.getZ(),
+                    false,
+                    mc.player.horizontalCollision
+            );
+            ((IPlayerMoveC2SPacket) homepacket).meteor$setTag(1337);
+            ((IPlayerMoveC2SPacket) movepacket).meteor$setTag(1337);
+            mc.player.networkHandler.sendPacket(movepacket);
+            mc.player.networkHandler.sendPacket(homepacket);
+
+            // tiny upward thrust & no fallDistance
+            mc.player.setVelocity(mc.player.getVelocity().x, 0.1, mc.player.getVelocity().z);
+            mc.player.fallDistance = 0;
         }
     }
 
@@ -122,18 +113,16 @@ public class MaceKill extends Module {
         int maxHeight = playerPos.getY() + (maxPower.get() ? 170 : fallHeight.get());
 
         for (int i = maxHeight; i > playerPos.getY(); i--) {
-            BlockPos isopenair1 = new BlockPos(playerPos.getX(), i, playerPos.getZ());
-            BlockPos isopenair2 = isopenair1.up(1);
-            if (isSafeBlock(isopenair1) && isSafeBlock(isopenair2)) {
-                return i - playerPos.getY();
-            }
+            BlockPos up1 = new BlockPos(playerPos.getX(), i, playerPos.getZ());
+            BlockPos up2 = up1.up(1);
+            if (isSafeBlock(up1) && isSafeBlock(up2)) return i - playerPos.getY();
         }
         return 0; // Return 0 if no suitable position is found
     }
 
     private boolean isSafeBlock(BlockPos pos) {
         return mc.world.getBlockState(pos).isReplaceable()
-                && mc.world.getFluidState(pos).isEmpty()
-                && !mc.world.getBlockState(pos).isOf(Blocks.POWDER_SNOW);
+            && mc.world.getFluidState(pos).isEmpty()
+            && !mc.world.getBlockState(pos).isOf(Blocks.POWDER_SNOW);
     }
 }


### PR DESCRIPTION
**What’s up:**  
When the teleport back to ground doesn’t sync perfectly, you’d bonk the ground and insta‑die. Now you land half‑a‑block above your original spot, get a tiny upward bounce, and `fallDistance` is reset, so if it ever mis‑syncs, you just score a regular critical hit (still hurts the mob/player) instead of eating dust.

---

**Changes:**  
- Home teleport Y = `previousY + 0.5` instead of exact ground  
- After teleport, `setVelocity(…, 0.1, …)` for a little bounce  
- Reset `player.fallDistance = 0`  

---

**Why:**  
No more accidental self‑kills. The poor bastard still takes full mace damage/knockback, and any mis‑sync just drops in as a normal crit hit.

---

**Tested:**  
- Swings up to 170 blocks on Paper & Spigot  
- Confirmed you never take fall damage, even on packet hiccups  

---

Merge away!