### PR TITLE
Remove trident from mobgearesp

### DIFF
--- a/src/main/java/pwn/noobs/trouserstreak/modules/MobGearESP.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/MobGearESP.java
@@ -49,7 +49,6 @@ public class MobGearESP extends Module {
             Items.NETHERITE_BOOTS,
             Items.ELYTRA,
             Items.MACE,
-            Items.TRIDENT,
             Items.DIAMOND_SWORD,
             Items.DIAMOND_AXE,
             Items.DIAMOND_PICKAXE,
@@ -429,4 +428,5 @@ public class MobGearESP extends Module {
                 });
             }
         }
+
 }


### PR DESCRIPTION
Remove trident from item list to remove false positives from the drowneds