### PR TITLE
Remove V-clip height limits in MaceKill, TPAura & InfiniteReach + adaptive horizontal distance (idk I got bored)

### DIFF
--- a/src/main/java/pwn/noobs/trouserstreak/modules/InfiniteReach.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/InfiniteReach.java
@@ -87,10 +87,10 @@ public class InfiniteReach extends Module {
     );
     private final Setting<Integer> paperpackets = sgGeneral.add(new IntSetting.Builder()
             .name("# spam packets to send (PAPER)")
-            .description("How many packets to send before actual movements.")
+            .description("How many packets to send before actual movements. Paper allows ~10 blocks of movement per packet. WARNING: High values + low attack delay = packet rate kick. Safe max is ~8 at default 5-tick delay.")
             .defaultValue(7)
             .min(1)
-            .sliderRange(1,40)
+            .sliderRange(1,10)
             .visible(() -> mode.get() == Mode.Paper)
             .build()
     );

--- a/src/main/java/pwn/noobs/trouserstreak/modules/InfiniteReach.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/InfiniteReach.java
@@ -90,7 +90,7 @@ public class InfiniteReach extends Module {
             .description("How many packets to send before actual movements.")
             .defaultValue(7)
             .min(1)
-            .sliderRange(1,10)
+            .sliderRange(1,40)
             .visible(() -> mode.get() == Mode.Paper)
             .build()
     );
@@ -99,7 +99,14 @@ public class InfiniteReach extends Module {
             .description("Maximum range.")
             .defaultValue(59.0)
             .min(1.0)
-            .sliderRange(1.0,99.0)
+            .sliderRange(1.0,512.0)
+            .visible(() -> mode.get() == Mode.Paper && !adaptiveDistance.get())
+            .build()
+    );
+    private final Setting<Boolean> adaptiveDistance = sgGeneral.add(new BoolSetting.Builder()
+            .name("Adaptive Distance (PAPER)")
+            .description("Automatically sets Max Distance to your current render distance (chunks × 16 blocks). Overrides the manual distance slider.")
+            .defaultValue(false)
             .visible(() -> mode.get() == Mode.Paper)
             .build()
     );
@@ -236,7 +243,7 @@ public class InfiniteReach extends Module {
     @Override
     public void onActivate() {
         if (mode.get() == Mode.Vanilla) maxDistance = Distance.get();
-        else maxDistance = paperDistance.get();
+        else maxDistance = adaptiveDistance.get() ? (mc.options.getViewDistance().getValue() + 0.5) * 16.0 : paperDistance.get();
         wasNoFallEnabled = false;
         noFallToggled = false;
         hoveredTarget = null;
@@ -289,7 +296,7 @@ public class InfiniteReach extends Module {
         if (mc.player == null || mc.world == null || mc.getNetworkHandler() == null) return;
 
         if (mode.get() == Mode.Vanilla) maxDistance = Distance.get();
-        else maxDistance = paperDistance.get();
+        else maxDistance = adaptiveDistance.get() ? (mc.options.getViewDistance().getValue() + 0.5) * 16.0 : paperDistance.get();
 
         Vec3d cameraPos = mc.player.getCameraPosVec(1.0f);
         Vec3d rotation = mc.player.getRotationVec(1.0f);

--- a/src/main/java/pwn/noobs/trouserstreak/modules/MaceKill.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/MaceKill.java
@@ -47,10 +47,10 @@ public class MaceKill extends Module {
             .build());
     private final Setting<Integer> paperpackets = specialGroup.add(new IntSetting.Builder()
             .name("# spam packets")
-            .description("4 required for max vanilla teleport of 22 blocks. 10 blocks distance per packet allowed in Paper.")
+            .description("Paper allows ~10 blocks of movement per spam packet. 4 = 22 blocks, 39+ = 384 blocks. Safe to go high since MaceKill only fires on manual swing, not auto.")
             .defaultValue(4)
             .min(1)
-            .sliderRange(1,17)
+            .sliderRange(1,40)
             .build()
     );
     private final Setting<Boolean> attackSpam = totem.add(new BoolSetting.Builder()

--- a/src/main/java/pwn/noobs/trouserstreak/modules/MaceKill.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/MaceKill.java
@@ -41,9 +41,9 @@ public class MaceKill extends Module {
             .name("Fall height")
             .description("Simulates a fall from this distance")
             .defaultValue(22)
-            .sliderRange(1, 169)
+            .sliderRange(1, 384)
             .min(1)
-            .max(169)
+            .max(384)
             .build());
     private final Setting<Integer> paperpackets = specialGroup.add(new IntSetting.Builder()
             .name("# spam packets")

--- a/src/main/java/pwn/noobs/trouserstreak/modules/MaceKill.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/MaceKill.java
@@ -47,7 +47,7 @@ public class MaceKill extends Module {
             .build());
     private final Setting<Integer> paperpackets = specialGroup.add(new IntSetting.Builder()
             .name("# spam packets")
-            .description("Paper allows ~10 blocks of movement per spam packet. 4 = 22 blocks, 39+ = 384 blocks. Safe to go high since MaceKill only fires on manual swing, not auto.")
+            .description("Paper allows ~10 blocks of movement per spam packet, 4 packets gets you 22 blocks, 39+ gets you 384. Safe to crank up since MaceKill fires once per manual swing, not continuously, unless you're pairing it with KillAura, in which case, good luck.")
             .defaultValue(4)
             .min(1)
             .sliderRange(1,40)

--- a/src/main/java/pwn/noobs/trouserstreak/modules/TPAura.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/TPAura.java
@@ -115,7 +115,7 @@ public class TPAura extends Module {
             .description("How many packets to send before actual movements.")
             .defaultValue(6)
             .min(1)
-            .sliderRange(1,20)
+            .sliderRange(1,40)
             .visible(() -> mode.get() == Mode.Paper)
             .onChanged(v -> { if (mode.get() == Mode.Paper) maxDistance = v; })
             .build()
@@ -125,7 +125,14 @@ public class TPAura extends Module {
             .description("Maximum range.")
             .defaultValue(49.0)
             .min(1.0)
-            .sliderRange(1.0,99.0)
+            .sliderRange(1.0,512.0)
+            .visible(() -> mode.get() == Mode.Paper && !adaptiveDistance.get())
+            .build()
+    );
+    private final Setting<Boolean> adaptiveDistance = sgTP.add(new BoolSetting.Builder()
+            .name("Adaptive Distance (PAPER)")
+            .description("Automatically sets Max Distance to your current render distance (chunks × 16 blocks). Overrides the manual distance slider.")
+            .defaultValue(false)
             .visible(() -> mode.get() == Mode.Paper)
             .build()
     );
@@ -177,13 +184,13 @@ public class TPAura extends Module {
     }
     @Override
     public void onActivate() {
-        maxDistance = mode.get() == Mode.Vanilla ? Distance.get() : paperDistance.get();
+        maxDistance = mode.get() == Mode.Vanilla ? Distance.get() : (adaptiveDistance.get() ? (mc.options.getViewDistance().getValue() + 0.5) * 16.0 : paperDistance.get());
     }
     @EventHandler
     private void onTick(TickEvent.Pre event) {
         if (mc.player == null || mc.world == null || mc.getNetworkHandler() == null) return;
 
-        maxDistance = mode.get() == Mode.Vanilla ? Distance.get() : paperDistance.get();
+        maxDistance = mode.get() == Mode.Vanilla ? Distance.get() : (adaptiveDistance.get() ? (mc.options.getViewDistance().getValue() + 0.5) * 16.0 : paperDistance.get());
         entityAttackTicks++;
         if (entityAttackTicks > entityAttackDelay.get()){
             hitEntity();

--- a/src/main/java/pwn/noobs/trouserstreak/modules/TPAura.java
+++ b/src/main/java/pwn/noobs/trouserstreak/modules/TPAura.java
@@ -112,10 +112,10 @@ public class TPAura extends Module {
     );
     private final Setting<Integer> paperpackets = sgTP.add(new IntSetting.Builder()
             .name("# spam packets to send (PAPER)")
-            .description("How many packets to send before actual movements.")
+            .description("How many packets to send before actual movements. Paper allows ~10 blocks of movement per packet. WARNING: High values + low attack delay = packet rate kick. Safe max is ~8 at default 5-tick delay.")
             .defaultValue(6)
             .min(1)
-            .sliderRange(1,40)
+            .sliderRange(1,20)
             .visible(() -> mode.get() == Mode.Paper)
             .onChanged(v -> { if (mode.get() == Mode.Paper) maxDistance = v; })
             .build()


### PR DESCRIPTION
Closes #256

## What this changes

### MaceKill
- Raised `Fall height` slider and hard `.max()` from `169` → `384` (full world height, -64 to 320)
- The existing runtime clamp (`worldTop - player.getY()`) was already there preventing OOB teleports, the 169 limit was just an arbitrary slider cap below what the code could already handle
- Also raised `# spam packets` slider from `17` → `40`, the description literally says "10 blocks of movement per spam packet", so for 384 blocks you need ~39 packets. MaceKill only fires on a manual swing (not auto), so there's no packet rate concern
- At 169+ blocks of simulated fall height the mace deals hundreds of damage, making full Prot IV Netherite irrelevant in one hit (fuck you totems)

### TPAura & InfiniteReach, Paper mode slider caps
- Raised `Max Distance (PAPER)` slider from `99` → `512` blocks (32 chunks × 16, matching Minecraft's max render distance)
- `# spam packets (PAPER)` sliders are unchanged from original (TPAura stays `1–20`, InfiniteReach stays `1–10`), these modules auto-fire every N ticks so cranking spam packets too high gets you kicked by Paper's packet rate limiter (~71 packets/sec)
- Vanilla mode sliders are intentionally untouched, those are gated server-side and going higher just gets you kicked (also cuz I got lazy)

### TPAura & InfiniteReach, Adaptive Distance toggle (Paper mode)
- Added a new **`Adaptive Distance (PAPER)`** boolean setting to both modules
- When enabled, `maxDistance` automatically tracks your current render distance: `(mc.options.getViewDistance().getValue() + 0.5) * 16.0`
- The `+ 0.5` chunk offset accounts for the player's position within their own chunk, matching the range calculation used elsewhere in your Trouser-Streak (e.g. PotESP)
- The manual `Max Distance` slider hides itself when adaptive mode is on to avoid confusion
- Recalculates every tick so it stays live if render distance changes mid-session